### PR TITLE
Add basic process manager implementation with double event bus

### DIFF
--- a/src/ContextServiceProvider.php
+++ b/src/ContextServiceProvider.php
@@ -5,6 +5,7 @@ namespace Madewithlove\LaravelCqrsEs;
 use Broadway\EventHandling\EventBusInterface;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
+use ReplayingEventBusInterface;
 
 abstract class ContextServiceProvider extends EventServiceProvider
 {
@@ -14,14 +15,29 @@ abstract class ContextServiceProvider extends EventServiceProvider
     protected $projectors = [];
 
     /**
+     * @var array
+     */
+    protected $processManagers = [];
+
+    /**
      * @param DispatcherContract $events
      */
     public function boot(DispatcherContract $events)
     {
         /** @var EventBusInterface $eventBus */
-        $eventBus = $this->app->make(EventBusInterface::class);
+        $liveEventBus = $this->app->make(EventBusInterface::class);
+        $replayOnlyEventBus = $this->app->make(ReplayingEventBusInterface::class);
+
+        // Subscribe Projectors to both live events and replayed events
         foreach ($this->projectors as $projector) {
-            $eventBus->subscribe($this->app->make($projector));
+            $projectorInstance = $this->app->make($projector);
+            $liveEventBus->subscribe($projectorInstance);
+            $replayOnlyEventBus->subscribe($projectorInstance);
+        }
+
+        // Subscribe ProcessManagers only to live events
+        foreach ($this->processManagers as $processManager) {
+            $liveEventBus->subscribe($this->app->make($processManager));
         }
         parent::boot($events);
     }

--- a/src/ContextServiceProvider.php
+++ b/src/ContextServiceProvider.php
@@ -5,7 +5,7 @@ namespace Madewithlove\LaravelCqrsEs;
 use Broadway\EventHandling\EventBusInterface;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
-use ReplayingEventBusInterface;
+use Madewithlove\LaravelCqrsEs\EventHandling\ReplayingEventBusInterface;
 
 abstract class ContextServiceProvider extends EventServiceProvider
 {

--- a/src/EventHandling/ReplayingEventBusInterface.php
+++ b/src/EventHandling/ReplayingEventBusInterface.php
@@ -1,4 +1,6 @@
 <?php
+namespace Madewithlove\LaravelCqrsEs\EventHandling;
+
 use Broadway\EventHandling\EventBusInterface;
 
 /**

--- a/src/EventHandling/ReplayingEventBusInterface.php
+++ b/src/EventHandling/ReplayingEventBusInterface.php
@@ -1,0 +1,10 @@
+<?php
+use Broadway\EventHandling\EventBusInterface;
+
+/**
+ * Use this event bus only for replays.
+ * Only listeners that are interested in replayed events should subscribe to this.
+ */
+interface ReplayingEventBusInterface extends EventBusInterface
+{
+}

--- a/src/EventStore/ServiceProvider.php
+++ b/src/EventStore/ServiceProvider.php
@@ -9,6 +9,7 @@ use Broadway\EventHandling\SimpleEventBus;
 use Broadway\EventStore\EventStoreInterface;
 use Broadway\EventStore\Management\EventStoreManagementInterface;
 use Madewithlove\LaravelCqrsEs\EventStore\Console\Replay;
+use ReplayingEventBusInterface;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
@@ -36,7 +37,9 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->app->singleton(EventBusInterface::class, function () {
             return new SimpleEventBus();
         });
-
+        $this->app->singleton(ReplayingEventBusInterface::class, function () {
+            return new SimpleEventBus();
+        });
         $this->app->alias('event_store.driver', EventStoreInterface::class);
         $this->app->alias('event_store.driver', EventStoreManagementInterface::class);
     }

--- a/src/EventStore/Services/Replay.php
+++ b/src/EventStore/Services/Replay.php
@@ -7,6 +7,7 @@ use Broadway\EventHandling\EventBusInterface;
 use Broadway\EventStore\CallableEventVisitor;
 use Broadway\EventStore\Management\Criteria;
 use Broadway\EventStore\Management\EventStoreManagementInterface;
+use Madewithlove\LaravelCqrsEs\EventHandling\ReplayingEventBusInterface;
 
 class Replay
 {
@@ -31,10 +32,10 @@ class Replay
     protected $eventBufferSize = 20;
 
     /**
-     * @param EventBusInterface $eventBus
+     * @param ReplayingEventBusInterface $eventBus
      * @param EventStoreManagementInterface $eventManager
      */
-    public function __construct(EventBusInterface $eventBus, EventStoreManagementInterface $eventManager)
+    public function __construct(ReplayingEventBusInterface $eventBus, EventStoreManagementInterface $eventManager)
     {
         $this->eventBus = $eventBus;
         $this->eventManager = $eventManager;

--- a/src/Inflectors/HandleClassNameInflector.php
+++ b/src/Inflectors/HandleClassNameInflector.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Madewithlove\LaravelCqrsEs\Inflectors;
+
+class HandleClassNameInflector implements MethodNameInflector
+{
+    /**
+     * @param $event
+     * @return string
+     */
+    public function inflect($event)
+    {
+        $classParts = explode('\\', get_class($event));
+        return 'handle' . end($classParts);
+    }
+}

--- a/src/Inflectors/MethodNameInflector.php
+++ b/src/Inflectors/MethodNameInflector.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Madewithlove\LaravelCqrsEs\ReadModel;
+namespace Madewithlove\LaravelCqrsEs\Inflectors;
 
 interface MethodNameInflector
 {

--- a/src/Inflectors/ProjectClassNameInflector.php
+++ b/src/Inflectors/ProjectClassNameInflector.php
@@ -1,7 +1,6 @@
 <?php
 
-namespace Madewithlove\LaravelCqrsEs\ReadModel;
-
+namespace Madewithlove\LaravelCqrsEs\Inflectors;
 
 class ProjectClassNameInflector implements MethodNameInflector
 {

--- a/src/ProcessManager/ProcessManager.php
+++ b/src/ProcessManager/ProcessManager.php
@@ -1,29 +1,31 @@
 <?php
 
-namespace Madewithlove\LaravelCqrsEs\ReadModel;
 
 use Broadway\Domain\DomainMessage;
-use Broadway\ReadModel\ProjectorInterface;
+use Broadway\EventHandling\EventListenerInterface;
+use Illuminate\Foundation\Bus\DispatchesJobs;
 use Madewithlove\LaravelCqrsEs\Inflectors\MethodNameInflector;
 
-abstract class Projector implements ProjectorInterface
+abstract class ProcessManager implements EventListenerInterface
 {
+    use DispatchesJobs;
+
     /**
      * @var MethodNameInflector
      */
     private $methodNameInflector;
 
     /**
-     * Projector constructor.
-     * @param $methodNameInflector
+     * ProcessManager constructor.
+     * @param MethodNameInflector $methodNameInflector
      */
     public function __construct(MethodNameInflector $methodNameInflector)
     {
         $this->methodNameInflector = $methodNameInflector;
     }
-    
+
     /**
-     * {@inheritDoc}
+     * @param DomainMessage $domainMessage
      */
     public function handle(DomainMessage $domainMessage)
     {

--- a/src/ProcessManager/ProcessManager.php
+++ b/src/ProcessManager/ProcessManager.php
@@ -3,7 +3,6 @@
 
 use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventListenerInterface;
-use Illuminate\Foundation\Bus\DispatchesJobs;
 use Madewithlove\LaravelCqrsEs\Inflectors\MethodNameInflector;
 
 abstract class ProcessManager implements EventListenerInterface

--- a/src/ProcessManager/ProcessManager.php
+++ b/src/ProcessManager/ProcessManager.php
@@ -8,8 +8,6 @@ use Madewithlove\LaravelCqrsEs\Inflectors\MethodNameInflector;
 
 abstract class ProcessManager implements EventListenerInterface
 {
-    use DispatchesJobs;
-
     /**
      * @var MethodNameInflector
      */

--- a/src/ReadModel/ServiceProvider.php
+++ b/src/ReadModel/ServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace Madewithlove\LaravelCqrsEs\ReadModel;
 
+use Madewithlove\LaravelCqrsEs\Inflectors\MethodNameInflector;
+use Madewithlove\LaravelCqrsEs\Inflectors\ProjectClassNameInflector;
+
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
     /**


### PR DESCRIPTION
### Added

- Abstract `ProcessManager` class with `HandleClassNameInflector`
- Second "replay only" event bus to avoid process managers replaying events

### Changed

- Moved inflectors to their own namespace
- Made `Projector` class abstract