### PR TITLE
Use Laravel database configuration by default

### DIFF
--- a/config/broadway.php
+++ b/config/broadway.php
@@ -13,7 +13,7 @@ return [
     'event-store' => [
         'driver' => 'dbal',
         'dbal' => [
-            'connection' => 'mysql',
+            'connection' => env('DB_CONNECTION', 'mysql'),
             'table' => 'event_store',
         ],
     ],


### PR DESCRIPTION
### Changed

* Use the Laravel database configuration by default

---

In a Laravel app, it is safe to assume that the event-store will be the same database as the app it self, at least in most cases. This also solves the problem of that the migration (that creates the event-store table) runs on the wrong database.