### PR TITLE
Inject method name inflectors instead of explicitly requireing them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+### Unreleased
+
+### Changed
+
+- `MethodNameInflector` dependencies are now injected when resolving from the IoC.
+
+### Fixed
+
+- `Processor` classes now correctly require you to prefix methods with `process` instead of `project`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,18 @@
+# Upgrade
+
+## 0.8.0 -> 1.0.0
+
+### Removal of explicit `MethodNameInflector` dependency on `Projector` and `Processor` classes
+
+We removed the explicit `MethodNameInflector` dependency on `Projector` and `Processor` instances, instead this will be injected when the class is being resolved from the IoC container
+
+```diff
+class BookProjector extends Projector
+{
+-		public function __construct(MethodNameInflector $inflector, ReadRepository $readRepository)
++		public function __construct(ReadRepository $readRepository)
+		{
+	-     parent::__construct($inflector);
+				$this->readRepository = $readRepository;
+		}
+}

--- a/src/Inflectors/ClassNameInflector.php
+++ b/src/Inflectors/ClassNameInflector.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Madewithlove\LaravelCqrsEs\Inflectors;
+
+abstract class ClassNameInflector implements MethodNameInflector
+{
+    /**
+     * @var string
+     */
+    protected $prefix = 'handle';
+
+    /**
+     * @param $event
+     *
+     * @return string
+     */
+    public function inflect($event)
+    {
+        $classParts = explode('\\', get_class($event));
+
+        return $this->prefix.end($classParts);
+    }
+}

--- a/src/Inflectors/HandleClassNameInflector.php
+++ b/src/Inflectors/HandleClassNameInflector.php
@@ -2,15 +2,10 @@
 
 namespace Madewithlove\LaravelCqrsEs\Inflectors;
 
-class HandleClassNameInflector implements MethodNameInflector
+class HandleClassNameInflector extends ClassNameInflector
 {
     /**
-     * @param $event
-     * @return string
+     * @var string
      */
-    public function inflect($event)
-    {
-        $classParts = explode('\\', get_class($event));
-        return 'handle' . end($classParts);
-    }
+    protected $prefix = 'handle';
 }

--- a/src/Inflectors/ProcessClassNameInflector.php
+++ b/src/Inflectors/ProcessClassNameInflector.php
@@ -2,15 +2,10 @@
 
 namespace Madewithlove\LaravelCqrsEs\Inflectors;
 
-class ProcessClassNameInflector implements MethodNameInflector
+class ProcessClassNameInflector extends ClassNameInflector
 {
     /**
-     * @param $event
-     * @return string
+     * @var string
      */
-    public function inflect($event)
-    {
-        $classParts = explode('\\', get_class($event));
-        return 'process' . end($classParts);
-    }
+    protected $prefix = 'process';
 }

--- a/src/Inflectors/ProjectClassNameInflector.php
+++ b/src/Inflectors/ProjectClassNameInflector.php
@@ -2,15 +2,10 @@
 
 namespace Madewithlove\LaravelCqrsEs\Inflectors;
 
-class ProjectClassNameInflector implements MethodNameInflector
+class ProjectClassNameInflector extends ClassNameInflector
 {
     /**
-     * @param $event
-     * @return string
+     * @var string
      */
-    public function inflect($event)
-    {
-        $classParts = explode('\\', get_class($event));
-        return 'project' . end($classParts);
-    }
+    protected $prefix = 'project';
 }

--- a/src/Inflectors/ServiceProvider.php
+++ b/src/Inflectors/ServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Madewithlove\LaravelCqrsEs\Inflectors;
+
+use Madewithlove\LaravelCqrsEs\ProcessManager\Contracts\ProcessManager;
+use Madewithlove\LaravelCqrsEs\ReadModel\Contracts\Projector;
+
+class ServiceProvider extends \Illuminate\Support\ServiceProvider
+{
+    public function register()
+    {
+        $this->app->resolving(ProcessManager::class, function (ProcessManager $manager) {
+            return $manager->setInflector(new ProcessClassNameInflector());
+        });
+
+        $this->app->resolving(Projector::class, function (Projector $manager) {
+            return $manager->setInflector(new ProjectClassNameInflector());
+        });
+    }
+}

--- a/src/Inflectors/Traits/UsesInflector.php
+++ b/src/Inflectors/Traits/UsesInflector.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Madewithlove\LaravelCqrsEs\Inflectors\Traits;
+
+use Madewithlove\LaravelCqrsEs\Inflectors\MethodNameInflector;
+
+trait UsesInflector
+{
+    /**
+     * @var MethodNameInflector
+     */
+    private $methodNameInflector;
+
+    /**
+     * @param MethodNameInflector $inflector
+     *
+     * @return UsesInflector
+     */
+    public function setInflector(MethodNameInflector $inflector)
+    {
+        $this->methodNameInflector = $inflector;
+
+        return $this;
+    }
+}

--- a/src/ProcessManager/Contracts/ProcessManager.php
+++ b/src/ProcessManager/Contracts/ProcessManager.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Madewithlove\LaravelCqrsEs\ProcessManager\Contracts;
+
+use Broadway\EventHandling\EventListenerInterface;
+use Madewithlove\LaravelCqrsEs\Inflectors\MethodNameInflector;
+
+interface ProcessManager extends EventListenerInterface
+{
+    /**
+     * @param MethodNameInflector $inflector
+     *
+     * @return ProcessManager
+     */
+    public function setInflector(MethodNameInflector $inflector);
+}

--- a/src/ProcessManager/ProcessManager.php
+++ b/src/ProcessManager/ProcessManager.php
@@ -2,34 +2,22 @@
 namespace Madewithlove\LaravelCqrsEs\ProcessManager;
 
 use Broadway\Domain\DomainMessage;
-use Broadway\EventHandling\EventListenerInterface;
-use Madewithlove\LaravelCqrsEs\Inflectors\MethodNameInflector;
+use Madewithlove\LaravelCqrsEs\Inflectors\Traits\UsesInflector;
+use Madewithlove\LaravelCqrsEs\ProcessManager\Contracts\ProcessManager as ProcessManagerContract;
 
-abstract class ProcessManager implements EventListenerInterface
+abstract class ProcessManager implements ProcessManagerContract
 {
-    /**
-     * @var MethodNameInflector
-     */
-    private $methodNameInflector;
-
-    /**
-     * ProcessManager constructor.
-     * @param MethodNameInflector $methodNameInflector
-     */
-    public function __construct(MethodNameInflector $methodNameInflector)
-    {
-        $this->methodNameInflector = $methodNameInflector;
-    }
+    use UsesInflector;
 
     /**
      * @param DomainMessage $domainMessage
      */
     public function handle(DomainMessage $domainMessage)
     {
-        $event  = $domainMessage->getPayload();
+        $event = $domainMessage->getPayload();
         $method = $this->methodNameInflector->inflect($event);
 
-        if (! method_exists($this, $method)) {
+        if (!method_exists($this, $method)) {
             return;
         }
 

--- a/src/ReadModel/Contracts/Projector.php
+++ b/src/ReadModel/Contracts/Projector.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Madewithlove\LaravelCqrsEs\ReadModel\Contracts;
+
+use Broadway\ReadModel\ProjectorInterface;
+use Madewithlove\LaravelCqrsEs\Inflectors\MethodNameInflector;
+
+interface Projector extends ProjectorInterface
+{
+    /**
+     * @param MethodNameInflector $inflector
+     *
+     * @return Projector
+     */
+    public function setInflector(MethodNameInflector $inflector);
+}

--- a/src/ReadModel/Projector.php
+++ b/src/ReadModel/Projector.php
@@ -3,24 +3,12 @@
 namespace Madewithlove\LaravelCqrsEs\ReadModel;
 
 use Broadway\Domain\DomainMessage;
-use Broadway\ReadModel\ProjectorInterface;
-use Madewithlove\LaravelCqrsEs\Inflectors\MethodNameInflector;
+use Madewithlove\LaravelCqrsEs\Inflectors\Traits\UsesInflector;
+use Madewithlove\LaravelCqrsEs\ReadModel\Contracts\Projector as ProjectorContract;
 
-abstract class Projector implements ProjectorInterface
+abstract class Projector implements ProjectorContract
 {
-    /**
-     * @var MethodNameInflector
-     */
-    private $methodNameInflector;
-
-    /**
-     * Projector constructor.
-     * @param $methodNameInflector
-     */
-    public function __construct(MethodNameInflector $methodNameInflector)
-    {
-        $this->methodNameInflector = $methodNameInflector;
-    }
+    use UsesInflector;
     
     /**
      * {@inheritDoc}

--- a/src/ReadModel/ServiceProvider.php
+++ b/src/ReadModel/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Madewithlove\LaravelCqrsEs\ReadModel;
 
+use Broadway\ReadModel\ProjectorInterface;
 use Madewithlove\LaravelCqrsEs\Inflectors\MethodNameInflector;
 use Madewithlove\LaravelCqrsEs\Inflectors\ProjectClassNameInflector;
 
@@ -11,7 +12,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
      * @var bool
      */
     protected $defer = true;
-    
+
     /**
      * Register the service provider.
      *
@@ -19,8 +20,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(MethodNameInflector::class, ProjectClassNameInflector::class);
-
         $this->app->singleton(ReadModelManager::class, function () {
             return new ReadModelManager($this->app);
         });
@@ -29,14 +28,5 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->app->singleton('read_model.driver', function () {
             return $this->app->make('read_model.manager')->driver();
         });
-    }
-
-    public function provides()
-    {
-        return [
-            'read_model.driver',
-            'read_model.manager',
-            MethodNameInflector::class,
-        ];
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -12,6 +12,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         $this->app->register(EventStore\ServiceProvider::class);
         $this->app->register(ReadModel\ServiceProvider::class);
+        $this->app->register(Inflectors\ServiceProvider::class);
         $this->app->register(Serializers\ServiceProvider::class);
         $this->app->register(Reconstitution\ServiceProvider::class);
         $this->app->register(Uuid\ServiceProvider::class);

--- a/tests/ProcessManager/ProcessManagerTest.php
+++ b/tests/ProcessManager/ProcessManagerTest.php
@@ -4,7 +4,6 @@ namespace Madewithlove\LaravelCqrsEs\Tests\ReadModel;
 
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
-use Madewithlove\LaravelCqrsEs\Inflectors\ProcessClassNameInflector;
 use Madewithlove\LaravelCqrsEs\ProcessManager\ProcessManager;
 use Madewithlove\LaravelCqrsEs\Tests\Stubs\BookWasPurchased;
 use Madewithlove\LaravelCqrsEs\Tests\Stubs\BookWasReturned;
@@ -32,7 +31,7 @@ class ProcessManagerTest extends TestCase
 {
     public function testItCanProcessADomainMessage()
     {
-        $processor = new BooksProcessor(new ProcessClassNameInflector());
+        $processor = $this->app->make(BooksProcessor::class);
 
         $message = DomainMessage::recordNow('1', 1, new Metadata(), new BookWasPurchased());
         $processor->handle($message);
@@ -42,7 +41,7 @@ class ProcessManagerTest extends TestCase
 
     public function testItCannotProcessADomainMessage()
     {
-        $processor = new BooksProcessor(new ProcessClassNameInflector());
+        $processor = $this->app->make(BooksProcessor::class);
 
         $message = DomainMessage::recordNow('1', 1, new Metadata(), new BookWasReturned());
         $processor->handle($message);

--- a/tests/ReadModel/ProjectorTest.php
+++ b/tests/ReadModel/ProjectorTest.php
@@ -4,7 +4,6 @@ namespace Madewithlove\LaravelCqrsEs\Tests\ReadModel;
 
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
-use Madewithlove\LaravelCqrsEs\Inflectors\ProjectClassNameInflector;
 use Madewithlove\LaravelCqrsEs\ReadModel\Projector;
 use Madewithlove\LaravelCqrsEs\Tests\Stubs\BookWasPurchased;
 use Madewithlove\LaravelCqrsEs\Tests\Stubs\BookWasReturned;
@@ -33,7 +32,7 @@ class ProjectorTest extends TestCase
 {
     public function testItCanProjectADomainMessage()
     {
-        $projector = new BooksProjector(new ProjectClassNameInflector());
+        $projector = $this->app->make(BooksProjector::class);
 
         $message = DomainMessage::recordNow('1', 1, new Metadata(), new BookWasPurchased());
         $projector->handle($message);
@@ -43,7 +42,7 @@ class ProjectorTest extends TestCase
 
     public function testItCannotProjectADomainMessage()
     {
-        $projector = new BooksProjector(new ProjectClassNameInflector());
+        $projector = $this->app->make(BooksProjector::class);
 
         $message = DomainMessage::recordNow('1', 1, new Metadata(), new BookWasReturned());
         $projector->handle($message);


### PR DESCRIPTION
### Changed

- `MethodNameInflector` dependencies are now injected when resolving from the IoC.

### Fixed

- `Processor` classes now correctly require you to prefix methods with `process` instead of `project`.